### PR TITLE
feat: support customize model and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A simple cli wrapper for ChatGPT API, powered by GPT-3.5-turbo model.
 Get or create your OpenAI API Key from here: https://platform.openai.com/account/api-keys
 
 ```shell
-$ export OPENAI_API_KEY=xxx
-$ chatgpt
+export OPENAI_API_KEY=xxx
+chatgpt
 ```
 
 ## Installation
@@ -37,14 +37,26 @@ scoop bucket add j178 https://github.com/j178/scoop-bucket.git
 scoop install j178/chatgpt
 ```
 
-## Custom OpenAI API Endpoint
+## Customization
 
-If you cannot access to the default `api.openai.com` endpoint, you can use a custom endpoint by setting `OPENAI_API_ENDPOINT` environment variable.
+You can customize the model and parameters by creating a configuration file in `~/.config/chatgpt.json`.
 
-```shell
-export OPENAI_API_ENDPOINT=https://xxx.workers.dev/v1
+Here is the default configuration:
+
+```json
+{
+  "api_key": "sk-xxxxxx",
+  "endpoint": "https://api.openai.com/v1",
+  "prompt": "You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible.",
+  "model": "gpt-3.5-turbo",
+  "context_length": 6,
+  "stream": true,
+  "temperature": 0,
+  "max_tokens": 1024
+}
 ```
 
+If you cannot access to the default `https://api.openai.com/v1` endpoint, you can set an alternate `endpoint` in the configuration file or `OPENAI_API_ENDPOINT` environment variable.
 Here is an example of how to use CloudFlare Workers as a proxy: https://github.com/noobnooc/noobnooc/discussions/9
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/lipgloss v0.6.0
 	github.com/muesli/reflow v0.3.0
-	github.com/sashabaranov/go-openai v1.5.0
+	github.com/sashabaranov/go-openai v1.5.3
 )
 
 require (
@@ -25,6 +25,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.22 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/microcosm-cc/bluemonday v1.0.22 h1:p2tT7RNzRdCi0qmwxG+HbqD6ILkmwter1ZwVZn1oTxA=
 github.com/microcosm-cc/bluemonday v1.0.22/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
 github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a h1:jlDOeO5TU0pYlbc/y6PFguab5IjANI0Knrpg3u/ton4=
 github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
@@ -71,6 +73,8 @@ github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sashabaranov/go-openai v1.5.0 h1:4Gr/7g/KtVzW0ddn7TC2aUlyzvhZBIM+qRZ6Ae2kMa0=
 github.com/sashabaranov/go-openai v1.5.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.5.3 h1:o6n6dj0h9u+5mE1m+D8eT0zYhh7229o8ymDd2zDwAXU=
+github.com/sashabaranov/go-openai v1.5.3/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/main.go
+++ b/main.go
@@ -620,6 +620,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case answerMsg:
 		m.history.UpdatePending(string(msg), true)
 		m.chatgpt.done()
+		m.viewport.SetContent(m.history.View(m.viewport.Width))
+		m.viewport.GotoBottom()
 		m.textarea.Placeholder = "Send a message..."
 		m.textarea.Focus()
 	case errMsg:

--- a/main.go
+++ b/main.go
@@ -325,7 +325,11 @@ func (c *ChatGPT) send(messages []openai.ChatCompletionMessage) tea.Cmd {
 					resp, err := c.client.CreateChatCompletion(
 						context.Background(),
 						openai.ChatCompletionRequest{
-							Model: c.conf.Model,
+							Model:       c.conf.Model,
+							Messages:    messages,
+							MaxTokens:   c.conf.MaxTokens,
+							Temperature: c.conf.Temperature,
+							N:           1,
 						},
 					)
 					if err != nil {


### PR DESCRIPTION
Closes #22 

Support customize model and parameters through a config file in `~/.config/chatgpt.json`,
default configuration:
```json
{
  "api_key": "sk-xxxxxx",
  "endpoint": "https://api.openai.com/v1",
  "prompt": "You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible.",
  "model": "gpt-3.5-turbo",
  "context_length": 6,
  "stream": true,
  "temperature": 0,
  "max_tokens": 1024
}
```

TODO:
- [x] update readme
- [ ] release