### PR TITLE
feat: add option to open a new conversation at the beginning

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,13 +39,13 @@ var (
 )
 
 var (
-	version        = "dev"
-	date           = "unknown"
-	commit         = "HEAD"
-	debug          = os.Getenv("DEBUG") == "1"
-	promptKey      = flag.String("p", "", "Key of prompt defined in config file, or prompt itself")
-	showVersion    = flag.Bool("v", false, "Show version")
-	startNewPrompt = flag.Bool("n", false, "Start new prompt")
+	version              = "dev"
+	date                 = "unknown"
+	commit               = "HEAD"
+	debug                = os.Getenv("DEBUG") == "1"
+	promptKey            = flag.String("p", "", "Key of prompt defined in config file, or prompt itself")
+	showVersion          = flag.Bool("v", false, "Show version")
+	startNewConversation = flag.Bool("n", false, "Start new conversation")
 )
 
 type (
@@ -91,7 +91,7 @@ func main() {
 
 	conversations := NewConversationManager(conf)
 
-	if *startNewPrompt {
+	if *startNewConversation {
 		conversations.New(conf.Conversation)
 	}
 

--- a/main.go
+++ b/main.go
@@ -39,12 +39,13 @@ var (
 )
 
 var (
-	version     = "dev"
-	date        = "unknown"
-	commit      = "HEAD"
-	debug       = os.Getenv("DEBUG") == "1"
-	promptKey   = flag.String("p", "", "Key of prompt defined in config file, or prompt itself")
-	showVersion = flag.Bool("v", false, "Show version")
+	version        = "dev"
+	date           = "unknown"
+	commit         = "HEAD"
+	debug          = os.Getenv("DEBUG") == "1"
+	promptKey      = flag.String("p", "", "Key of prompt defined in config file, or prompt itself")
+	showVersion    = flag.Bool("v", false, "Show version")
+	startNewPrompt = flag.Bool("n", false, "Start new prompt")
 )
 
 type (
@@ -89,6 +90,11 @@ func main() {
 	}
 
 	conversations := NewConversationManager(conf)
+
+	if *startNewPrompt {
+		conversations.New(conf.Conversation)
+	}
+
 	p := tea.NewProgram(
 		initialModel(chatgpt, conversations),
 		// enable mouse motion will make text not able to select


### PR DESCRIPTION
This pull request adds a new feature to program by implementing the -n option to open a new prompt. I use this program assigned to a key binding in tmux. When I hit this key binding, it is mainly because I want to start a new conversation immediately. To address this use case, I created this PR.