### PR TITLE
feat: reuse or create new conversation by specified prompt

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -82,6 +82,16 @@ func (m *ConversationManager) New(conf ConversationConfig) *Conversation {
 	return c
 }
 
+func (m *ConversationManager) FindByPrompt(prompt string) *Conversation {
+	prompt = m.globalConf.LookupPrompt(prompt)
+	for _, c := range m.Conversations {
+		if m.globalConf.LookupPrompt(c.Config.Prompt) == prompt {
+			return c
+		}
+	}
+	return nil
+}
+
 func (m *ConversationManager) RemoveCurr() {
 	if len(m.Conversations) == 0 {
 		return
@@ -90,6 +100,20 @@ func (m *ConversationManager) RemoveCurr() {
 	if m.Idx >= len(m.Conversations) {
 		m.Idx = len(m.Conversations) - 1
 	}
+}
+
+func (m *ConversationManager) SetCurr(conv *Conversation) {
+	idx := -1
+	for i, c := range m.Conversations {
+		if c == conv {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return
+	}
+	m.Idx = idx
 }
 
 func (m *ConversationManager) Len() int {

--- a/main.go
+++ b/main.go
@@ -95,11 +95,13 @@ func main() {
 
 	conversations := NewConversationManager(conf)
 
-	// If prompt is specified, try to find conversation with the same prompt.
-	// If not found, start a new conversation
-	if *promptKey != "" {
+	if *startNewConversation {
+		conversations.New(conf.Conversation)
+	} else if *promptKey != "" {
+		// If prompt is specified, try to find conversation with the same prompt.
+		// If not found, start a new conversation
 		conv := conversations.FindByPrompt(*promptKey)
-		if conv == nil || *startNewConversation {
+		if conv == nil {
 			conversations.New(conf.Conversation)
 		} else {
 			conversations.SetCurr(conv)

--- a/main.go
+++ b/main.go
@@ -95,12 +95,14 @@ func main() {
 
 	conversations := NewConversationManager(conf)
 
-	if *startNewConversation {
-		conversations.New(conf.Conversation)
-	} else {
-		// Override current conversations prompt
-		if isFlagPassed("p") {
-			conversations.Curr().Config.Prompt = conf.Conversation.Prompt
+	// If prompt is specified, try to find conversation with the same prompt.
+	// If not found, start a new conversation
+	if *promptKey != "" {
+		conv := conversations.FindByPrompt(*promptKey)
+		if conv == nil || *startNewConversation {
+			conversations.New(conf.Conversation)
+		} else {
+			conversations.SetCurr(conv)
 		}
 	}
 
@@ -292,16 +294,4 @@ func containsCJK(s string) bool {
 		}
 	}
 	return false
-}
-
-func isFlagPassed(name string) bool {
-	found := false
-	flag.Visit(
-		func(f *flag.Flag) {
-			if f.Name == name {
-				found = true
-			}
-		},
-	)
-	return found
 }


### PR DESCRIPTION
This is a rework of #66, another approach to resolve #65

If user specified a prompt, we try to switch to the conversation with the same prompt. If not found, we create a new conversation with the prompt.

This way we avoid overwriting the prompt of previous conversation.