### PR TITLE
feat: use back pkoukk/tiktoken-go to support gpt-4o

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
+.conf
 go.work

--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/j178/tiktoken-go"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sashabaranov/go-openai"
 )
@@ -160,7 +159,8 @@ func InitConfig() (GlobalConfig, error) {
 	}
 
 	if conf.APIKey == "" {
-		return GlobalConfig{}, errors.New("Missing API key. Set it in `~/.config/chatgpt/config.json` or by setting the `OPENAI_API_KEY` environment variable. You can find or create your API key at https://platform.openai.com/account/api-keys.")
+		confDir := configDir()
+		return GlobalConfig{}, fmt.Errorf("Missing API key. Set it in `%s/config.json` or by setting the `OPENAI_API_KEY` environment variable. You can find or create your API key at https://platform.openai.com/account/api-keys.", confDir)
 	}
 
 	conf.APIType = openai.APIType(strings.ToUpper(string(conf.APIType)))
@@ -170,9 +170,5 @@ func InitConfig() (GlobalConfig, error) {
 		return GlobalConfig{}, fmt.Errorf("unknown API type: %s", conf.APIType)
 	}
 
-	_, err = tiktoken.ForModel(conf.Conversation.Model)
-	if err != nil {
-		return GlobalConfig{}, fmt.Errorf("invalid model %s", conf.Conversation.Model)
-	}
 	return conf, nil
 }

--- a/conversation.go
+++ b/conversation.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/j178/tiktoken-go"
 	"github.com/sashabaranov/go-openai"
 
 	"github.com/j178/chatgpt/tokenizer"
@@ -66,11 +65,7 @@ func (m *ConversationManager) Load() error {
 	if err != nil {
 		return err
 	}
-	for i, c := range m.Conversations {
-		_, err = tiktoken.ForModel(c.Config.Model)
-		if err != nil {
-			return fmt.Errorf("invalid model %s in conversation %d", c.Config.Model, i+1)
-		}
+	for _, c := range m.Conversations {
 		c.manager = m
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/j178/chatgpt
 
-go 1.21
-
-toolchain go1.21.3
+go 1.22
 
 require (
 	github.com/atotto/clipboard v0.1.4
@@ -11,10 +9,11 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/lipgloss v0.9.1
-	github.com/j178/tiktoken-go v0.0.0-20240117113851-e3c3d064f380
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/reflow v0.3.0
+	github.com/pkoukk/tiktoken-go v0.1.7
+	github.com/pkoukk/tiktoken-go-loader v0.0.2-0.20240522064338-c17e8bc0f699
 	github.com/postfinance/single v0.0.2
 	github.com/sashabaranov/go-openai v1.18.2
 )
@@ -25,6 +24,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
@@ -35,7 +35,6 @@ require (
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/yuin/goldmark v1.6.0 // indirect
 	github.com/yuin/goldmark-emoji v1.0.2 // indirect
 	golang.org/x/net v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,11 +25,11 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
-github.com/j178/tiktoken-go v0.0.0-20240117113851-e3c3d064f380 h1:noHIYe3PKmO3aAEzPBhgLPvFm3a2U5LXW0xJp4ZPPjk=
-github.com/j178/tiktoken-go v0.0.0-20240117113851-e3c3d064f380/go.mod h1:/TI2+hAOsK7rY9X9sSB2yNrSim0EcUBrBlFTTsNuud0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -58,6 +58,10 @@ github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/pkoukk/tiktoken-go v0.1.7 h1:qOBHXX4PHtvIvmOtyg1EeKlwFRiMKAcoMp4Q+bLQDmw=
+github.com/pkoukk/tiktoken-go v0.1.7/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
+github.com/pkoukk/tiktoken-go-loader v0.0.2-0.20240522064338-c17e8bc0f699 h1:Sp8yiuxsitkmCfEvUnmNf8wzuZwlGNkRjI2yF0C3QUQ=
+github.com/pkoukk/tiktoken-go-loader v0.0.2-0.20240522064338-c17e8bc0f699/go.mod h1:4mIkYyZooFlnenDlormIo6cd5wrlUKNr97wp9nGgEKo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/postfinance/single v0.0.2 h1:YLjLxxeGDnsW93oK4CxxOFSVOOiBi1OyoK4ZTl5biJw=
@@ -69,11 +73,8 @@ github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/sashabaranov/go-openai v1.18.2 h1:UnC307Mgc+fiIDUmEJCiCvRoMxdFrLtQlg8A594pnG8=
 github.com/sashabaranov/go-openai v1.18.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/tokenizer/tokenize.go
+++ b/tokenizer/tokenize.go
@@ -1,24 +1,48 @@
 package tokenizer
 
 import (
-	"github.com/j178/tiktoken-go"
+	"strings"
+
+	"github.com/pkoukk/tiktoken-go"
+	tiktokenloader "github.com/pkoukk/tiktoken-go-loader"
 	"github.com/sashabaranov/go-openai"
 )
 
+var encodings = map[string]*tiktoken.Tiktoken{}
+
+func init() {
+	tiktoken.SetBpeLoader(tiktokenloader.NewOfflineLoader())
+}
+
+func getEncoding(model string) (*tiktoken.Tiktoken, error) {
+	enc, ok := encodings[model]
+	if !ok {
+		var err error
+		enc, err = tiktoken.EncodingForModel(model)
+		if err != nil {
+			return nil, err
+		}
+		encodings[model] = enc
+	}
+	return enc, nil
+}
+
 func CountTokens(model, text string) int {
-	enc, err := tiktoken.ForModel(model)
+	enc, err := getEncoding(model)
 	if err != nil {
-		panic(err)
+		return 0
 	}
-	cnt, err := enc.Count(text)
-	if err != nil {
-		panic(err)
-	}
+	cnt := len(enc.Encode(text, nil, nil))
 	return cnt
 }
 
 // CountMessagesTokens based on https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
 func CountMessagesTokens(model string, messages []openai.ChatCompletionMessage) int {
+	enc, err := getEncoding(model)
+	if err != nil {
+		return 0
+	}
+
 	var (
 		tokens           int
 		tokensPerMessage int
@@ -37,23 +61,25 @@ func CountMessagesTokens(model string, messages []openai.ChatCompletionMessage) 
 	case "gpt-3.5-turbo-0301":
 		tokensPerMessage = 4 // every message follows <|start|>{role/name}\n{content}<|end|>\n
 		tokensPerName = -1   // if there's a name, the role is omitted
-	case "gpt-3.5-turbo":
-		// gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613.
-		return CountMessagesTokens("gpt-3.5-turbo-0613", messages)
-	case "gpt-4":
-		// gpt-4 may update over time. Returning num tokens assuming gpt-4-0613
-		return CountMessagesTokens("gpt-4-0613", messages)
 	default:
-		// not implemented
-		return 0
+		switch {
+		case strings.Contains(model, "gpt-3.5-turbo"):
+			// gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613.
+			return CountMessagesTokens("gpt-3.5-turbo-0613", messages)
+		case strings.Contains(model, "gpt-4"):
+			// gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.
+			return CountMessagesTokens("gpt-4-0613", messages)
+		default:
+			return 0
+		}
 	}
 
 	for k := range messages {
 		tokens += tokensPerMessage
 
-		tokens += CountTokens(model, messages[k].Role)
-		tokens += CountTokens(model, messages[k].Content)
-		tokens += CountTokens(model, messages[k].Name)
+		tokens += len(enc.Encode(messages[k].Role, nil, nil))
+		tokens += len(enc.Encode(messages[k].Content, nil, nil))
+		tokens += len(enc.Encode(messages[k].Name, nil, nil))
 		if messages[k].Name != "" {
 			tokens += tokensPerName
 		}


### PR DESCRIPTION
Again we change back to use github.com/pkoukk/tiktoken-go for gpt-4o support, and remove any model check to ensure future compatibility.
